### PR TITLE
[bugfix] Provider created content_library_vm_template successfully but produced an unexpected new value.

### DIFF
--- a/internal/provider/resource_content_library_vm_template.go
+++ b/internal/provider/resource_content_library_vm_template.go
@@ -195,7 +195,7 @@ func resourceContentLibraryVmTemplateCreate(ctx context.Context, d *schema.Resou
 		}
 		templates = response.Payload
 	} else {
-		return diag.FromErr((fmt.Errorf("must set src_vm_id")))
+		return diag.FromErr(fmt.Errorf("must set src_vm_id"))
 	}
 	d.SetId(*templates[0].Data.ID)
 	_, err := ct.WaitTasksFinish([]string{*templates[0].TaskID})
@@ -213,7 +213,9 @@ func resourceContentLibraryVmTemplateRead(ctx context.Context, d *schema.Resourc
 	gvtp := vm_template.NewGetVMTemplatesParams()
 	gvtp.RequestBody = &models.GetVMTemplatesRequestBody{
 		Where: &models.VMTemplateWhereInput{
-			ID: &id,
+			ContentLibraryVMTemplate: &models.ContentLibraryVMTemplateWhereInput{
+				ID: &id,
+			},
 		},
 	}
 	vmTemplates, err := ct.Api.VMTemplate.GetVMTemplates(gvtp)

--- a/internal/provider/resource_content_library_vm_template.go
+++ b/internal/provider/resource_content_library_vm_template.go
@@ -210,6 +210,7 @@ func resourceContentLibraryVmTemplateRead(ctx context.Context, d *schema.Resourc
 	ct := meta.(*cloudtower.Client)
 
 	id := d.Id()
+	num := int32(1)
 	gvtp := vm_template.NewGetVMTemplatesParams()
 	gvtp.RequestBody = &models.GetVMTemplatesRequestBody{
 		Where: &models.VMTemplateWhereInput{
@@ -217,6 +218,7 @@ func resourceContentLibraryVmTemplateRead(ctx context.Context, d *schema.Resourc
 				ID: &id,
 			},
 		},
+		First: &num,
 	}
 	vmTemplates, err := ct.Api.VMTemplate.GetVMTemplates(gvtp)
 	if err != nil {


### PR DESCRIPTION
 ### Files Changed
 - Update `internal/provider/resource_content_library_vm_template.go`.

### Relations
Closes: #18 