### PR TITLE
feat: add data source VM template attributes

### DIFF
--- a/internal/provider/data_source_content_library_vm_template.go
+++ b/internal/provider/data_source_content_library_vm_template.go
@@ -169,6 +169,36 @@ func dataSourceContentLibraryVmTemplate() *schema.Resource {
 										Computed:    true,
 										Description: "template's nics",
 									},
+									"cpu_cores": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "template's cpu cores",
+									},
+									"cpu_sockets": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "template's cpu sockets",
+									},
+									"memory": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "template's memory in the unit of byte, must be a multiple of 512MB, long value, ignore the decimal point",
+									},
+									"firmware": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "template's firmware, must be one of 'BIOS', 'UEFI'",
+									},
+									"clock_offset": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "template's clock offset, must be one of 'LOCALTIME', 'UTC'",
+									},
+									"win_opt": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: "template's win_opt",
+									},
 								},
 							},
 						},
@@ -283,10 +313,16 @@ func dataSourceContentLibraryVmTemplateRead(ctx context.Context, d *schema.Resou
 					})
 				}
 				vm_templates[idx] = map[string]interface{}{
-					"disks":   disks,
-					"nics":    nics,
-					"id":      rawTemplate.ID,
-					"cluster": rawTemplate.Cluster.ID,
+					"disks":        disks,
+					"nics":         nics,
+					"id":           rawTemplate.ID,
+					"cluster":      rawTemplate.Cluster.ID,
+					"cpu_cores":    rawTemplate.CPU.Cores,
+					"cpu_sockets":  rawTemplate.CPU.Sockets,
+					"memory":       rawTemplate.Memory,
+					"firmware":     rawTemplate.Firmware,
+					"clock_offset": rawTemplate.ClockOffset,
+					"win_opt":      rawTemplate.WinOpt,
 				}
 			}(template, ti)
 		}

--- a/internal/provider/data_source_vm_template.go
+++ b/internal/provider/data_source_vm_template.go
@@ -172,6 +172,36 @@ func dataSourceVmTemplate() *schema.Resource {
 							Computed:    true,
 							Description: "template's nics",
 						},
+						"cpu_cores": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "template's cpu cores",
+						},
+						"cpu_sockets": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "template's cpu sockets",
+						},
+						"memory": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "template's in the unit of byte, must be a multiple of 512MB, long value, ignore the decimal point",
+						},
+						"firmware": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "template's firmware, forcenew as it isn't able to modify after create, must be one of 'BIOS', 'UEFI'",
+						},
+						"clock_offset": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "template's clock offset, must be one of 'LOCALTIME', 'UTC'",
+						},
+						"win_opt": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "template's win_opt",
+						},
 					},
 				},
 			},
@@ -277,12 +307,18 @@ func dataSourceVmTemplateRead(ctx context.Context, d *schema.ResourceData, meta 
 			})
 		}
 		output = append(output, map[string]interface{}{
-			"id":          d.ID,
-			"name":        d.Name,
-			"create_time": d.LocalCreatedAt,
-			"disks":       disks,
-			"cd_roms":     cdroms,
-			"nics":        nics,
+			"id":           d.ID,
+			"name":         d.Name,
+			"create_time":  d.LocalCreatedAt,
+			"disks":        disks,
+			"cd_roms":      cdroms,
+			"nics":         nics,
+			"cpu_cores":    d.CPU.Cores,
+			"cpu_sockets":  d.CPU.Sockets,
+			"memory":       d.Memory,
+			"firmware":     d.Firmware,
+			"clock_offset": d.ClockOffset,
+			"win_opt":      d.WinOpt,
 		})
 	}
 	if diags.HasError() {


### PR DESCRIPTION
Add VM template attributes in data source: `cpu_cores`, `cpu_sockets`, `memory`, `firmware`, `clock_offset`, `win_opt`

**self test**

<img width="1232" height="2302" alt="image" src="https://github.com/user-attachments/assets/a94b06eb-47f1-4921-baab-16e2907b755c" />

```
vm_template = {
  "cluster_id_in" = tolist(null) /* of string */
  "cluster_in" = tolist(null) /* of string */
  "content_library_vm_templates" = tolist([
    {
      "create_time" = "2024-11-14T08:40:19.405Z"
      "id" = "cm3h283ppdpps0958rvopdhho"
      "name" = "win2016-cloudbase 1.1.4"
      "vm_templates" = tolist([
        {
          "clock_offset" = "LOCALTIME"
          "cluster" = "cm1prestz171q0958eiybjqg0"
          "cpu_cores" = 1
          "cpu_sockets" = 4
          "disks" = tolist([
            {
              "boot" = 1
              "bus" = "VIRTIO"
              "name" = "sks-registry-service-lHGA-0-volume-0"
              "path" = "iscsi://iqn.2016-02.com.smartx:system:zbs-iscsi-datastore-d0b51290-7a00-4ed5-a212-98fef3776a9c/45"
              "size" = 107374182400
              "storage_policy" = "REPLICA_2_THIN_PROVISION"
            },
          ])
          "firmware" = "BIOS"
          "id" = "cm3h283osdppf0958a4d9nn44"
          "memory" = 17179869184
          "nics" = tolist([
            {
              "enabled" = true
              "idx" = 0
              "mirror" = false
              "model" = "VIRTIO"
              "vlan_id" = "cm1preww5000610l8c5szd5ms"
            },
          ])
          "win_opt" = true
        },
      ])
    },
  ])
  "id" = "1754886840"
  "name" = "win2016-cloudbase 1.1.4"
  "name_contains" = tostring(null)
  "name_in" = tostring(null)
}
```

<img width="1236" height="2318" alt="image" src="https://github.com/user-attachments/assets/075bf5bc-718a-4851-8e39-add41f8bd389" />

```
vm_template = {
  "cluster_id_in" = tolist(null) /* of string */
  "cluster_in" = tolist(null) /* of string */
  "content_library_vm_templates" = tolist([
    {
      "create_time" = "2025-03-25T04:18:03.520Z"
      "id" = "cm8nzjf5s0jfg09582y4x9z92"
      "name" = "win 2022-template"
      "vm_templates" = tolist([
        {
          "clock_offset" = "LOCALTIME"
          "cluster" = "cm1prestz171q0958eiybjqg0"
          "cpu_cores" = 4
          "cpu_sockets" = 2
          "disks" = tolist([
            {
              "boot" = 1
              "bus" = "VIRTIO"
              "name" = ""
              "path" = "iscsi://iqn.2016-02.com.smartx:system:zbs-iscsi-datastore-ca1f67ca-2129-43d1-a5de-f992665595db/41"
              "size" = 214748364800
              "storage_policy" = "REPLICA_1_THIN_PROVISION"
            },
          ])
          "firmware" = "UEFI"
          "id" = "cm8nzjf510jf70958qktz2tci"
          "memory" = 17179869184
          "nics" = tolist([
            {
              "enabled" = true
              "idx" = 0
              "mirror" = false
              "model" = "VIRTIO"
              "vlan_id" = "cm1preww5000610l8c5szd5ms"
            },
          ])
          "win_opt" = true
        },
      ])
    },
  ])
  "id" = "1754887119"
  "name" = "win 2022-template"
  "name_contains" = tostring(null)
  "name_in" = tostring(null)
}
```

<img width="1248" height="2284" alt="image" src="https://github.com/user-attachments/assets/6bd790ef-a3b4-44b2-bfd0-7df1c6038b0d" />

```
vm_template = {
  "cluster_id_in" = tolist(null) /* of string */
  "cluster_in" = tolist(null) /* of string */
  "content_library_vm_templates" = tolist([
    {
      "create_time" = "2024-11-11T06:27:18.195Z"
      "id" = "cm3cn5hdf7lh20958jtxgtmec"
      "name" = "Ubunut22.04 标准"
      "vm_templates" = tolist([
        {
          "clock_offset" = "UTC"
          "cluster" = "cm1prestz171q0958eiybjqg0"
          "cpu_cores" = 1
          "cpu_sockets" = 4
          "disks" = tolist([
            {
              "boot" = 1
              "bus" = "VIRTIO"
              "name" = ""
              "path" = "iscsi://iqn.2016-02.com.smartx:system:zbs-iscsi-datastore-d0b51290-7a00-4ed5-a212-98fef3776a9c/251"
              "size" = 107374182400
              "storage_policy" = "REPLICA_2_THIN_PROVISION"
            },
          ])
          "firmware" = "BIOS"
          "id" = "cm3cn5hbx7lgr0958ejpcb9dy"
          "memory" = 8589934592
          "nics" = tolist([
            {
              "enabled" = true
              "idx" = 0
              "mirror" = false
              "model" = "VIRTIO"
              "vlan_id" = "cm1preww5000610l8c5szd5ms"
            },
          ])
          "win_opt" = false
        },
        {
          "clock_offset" = "UTC"
          "cluster" = "cmcj4w4w8vlka09588exzd1cc"
          "cpu_cores" = 1
          "cpu_sockets" = 4
          "disks" = tolist([
            {
              "boot" = 1
              "bus" = "VIRTIO"
              "name" = ""
              "path" = "iscsi://iqn.2016-02.com.smartx:system:zbs-iscsi-datastore-19962d11-4505-4420-bf2e-ec10440188df/172"
              "size" = 107374182400
              "storage_policy" = "REPLICA_2_THIN_PROVISION"
            },
          ])
          "firmware" = "BIOS"
          "id" = "cme2kz0xs9twk0858l4d738cq"
          "memory" = 8589934592
          "nics" = tolist([
            {
              "enabled" = true
              "idx" = 0
              "mirror" = false
              "model" = "VIRTIO"
              "vlan_id" = "cmcj4w7sj0gjldoyjv3v6kfu4"
            },
          ])
          "win_opt" = false
        },
      ])
    },
  ])
  "id" = "1754887165"
  "name" = "Ubunut22.04 标准"
  "name_contains" = tostring(null)
  "name_in" = tostring(null)
}
```